### PR TITLE
構造体のまま保存できるようにする

### DIFF
--- a/api/db/db.go
+++ b/api/db/db.go
@@ -6,28 +6,32 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
+	"github.com/kohei-kohei/go-redis/domain"
 )
 
-type Bread struct {
+type bread struct {
 	ID        int       `db:"id"`
 	Name      string    `db:"name"`
 	CreatedAt time.Time `db:"created_at"`
 }
 
-func GetBread(id int) (*Bread, error) {
+func GetBread(id int) (*domain.Bread, error) {
 	db, err := sqlx.Open("mysql", "go_test:password@tcp(db:3306)/go_database?parseTime=true")
 	defer db.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	var bread Bread
-	err = db.Get(&bread, "SELECT * FROM bread WHERE id = ?", id)
+	var b bread
+	err = db.Get(&b, "SELECT * FROM bread WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}
 
-	return &bread, nil
+	return &domain.Bread{
+		ID:   b.ID,
+		Name: b.Name,
+	}, nil
 }

--- a/api/domain/bread.go
+++ b/api/domain/bread.go
@@ -1,0 +1,6 @@
+package domain
+
+type Bread struct {
+	ID   int
+	Name string
+}

--- a/api/main.go
+++ b/api/main.go
@@ -40,7 +40,6 @@ func getBreadName(c *gin.Context) {
 	if value != "" {
 		b := domain.Bread{}
 		json.Unmarshal([]byte(value), &b)
-		fmt.Print(b)
 		c.JSON(http.StatusOK, gin.H{
 			"bread": value,
 		})

--- a/api/main.go
+++ b/api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/kohei-kohei/go-redis/cache"
 	"github.com/kohei-kohei/go-redis/db"
+	"github.com/kohei-kohei/go-redis/domain"
 )
 
 func main() {
@@ -36,6 +38,9 @@ func getBreadName(c *gin.Context) {
 	}
 
 	if value != "" {
+		b := domain.Bread{}
+		json.Unmarshal([]byte(value), &b)
+		fmt.Print(b)
 		c.JSON(http.StatusOK, gin.H{
 			"bread": value,
 		})
@@ -56,7 +61,8 @@ func getBreadName(c *gin.Context) {
 		return
 	}
 
-	if err := cache.Set(c, key, bread.Name); err != nil {
+	serialized, _ := json.Marshal(bread)
+	if err := cache.Set(c, key, string(serialized)); err != nil {
 		log.Println(err)
 	}
 


### PR DESCRIPTION
## やったこと

- domainオブジェクトっぽいものを用意
- 構造体のままJSONでRedisに保存できるようにする

## 今後

RedisJsonを使えばシリアライズする必要がなくなるので実装してみる
Redis側にも対応が必要そう

参考：https://zenn.dev/tk42/books/adbf4f87beed12/viewer/69b4d0
